### PR TITLE
Swagger2 >= 0.68 required

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -20,6 +20,8 @@ perl = v5.8.0
 ; see https://github.com/PerlDancer/Dancer2/commit/29702d6
 Dancer2 = 0.162000_01
 
+Swagger2 = 0.68
+
 [PruneFiles]
 match = ^cover_db/
 


### PR DESCRIPTION
I saw that in this test
http://www.cpantesters.org/cpan/report/5c7ccb38-efce-11e5-9198-e7ecfcd2507e
Swagger2 0.12 is installed. I tried several versions and it seems we need
at least 0.68
