### PR TITLE
fix for handling non-body input parameters (integers, booleans, undef)

### DIFF
--- a/lib/Dancer2/Plugin/Swagger2.pm
+++ b/lib/Dancer2/Plugin/Swagger2.pm
@@ -226,6 +226,17 @@ sub _validate_request {
 
 
             my $value  = $values[0];
+
+            # TODO steal more from Mojolicious::Plugin::Swagger2 ;-)
+            if ($type and defined ($value //= $parameter_spec->{default})) {
+                if (($type eq 'integer' or $type eq 'number') and $value =~ /^-?\d/) {
+                    $value += 0;
+                }
+                elsif ($type eq 'boolean') {
+                    $value = (!$value or $value eq 'false') ? '' : 1;
+                }
+            }
+
             my %input  = defined $value ? ( $name => $value ) : ();
             my %schema = ( properties => { $name => $parameter_spec } );
 

--- a/lib/Dancer2/Plugin/Swagger2.pm
+++ b/lib/Dancer2/Plugin/Swagger2.pm
@@ -224,8 +224,9 @@ sub _validate_request {
                 next;
             }
 
+
             my $value  = $values[0];
-            my %input  = ( $name => $value );
+            my %input  = defined $value ? ( $name => $value ) : ();
             my %schema = ( properties => { $name => $parameter_spec } );
 
             $required and $schema{required} = [$name];


### PR DESCRIPTION
Undefined Parameters:

Parameters in the query string can either be missing from the request
at all, or their value is at least the empty string.
At the moment, all optional parameters are added to the %input hash, but with
the value undef, and the schema usually does not allow that.

Integers, Booleans:
Convert strings into real integers or perl booleans

There's probably more to implement, also see Mojolicious::Plugin::Swagger2
http://swagger.io/specification/#parameterIn
