### PR TITLE
Replace Module::Load with Module::Runtime

### DIFF
--- a/lib/Dancer2/Plugin/Swagger2.pm
+++ b/lib/Dancer2/Plugin/Swagger2.pm
@@ -8,7 +8,7 @@ use warnings;
 
 use Dancer2 ':syntax';
 use Dancer2::Plugin;
-use Module::Load;
+use Module::Runtime 'use_module';
 use Swagger2;
 use Swagger2::SchemaValidator;
 
@@ -344,9 +344,8 @@ sub _default_controller_factory {
     # check candidates
     for my $controller (@controller_candidates) {
         local $@;
-        eval { load $controller };
-        if ($@) {
-            if ( $@ =~ m/^Can't locate / ) {    # module doesn't exist
+        if ( ! eval { use_module( $controller ); 1; } ) {
+            if ( $@ && $@ =~ m/^Can't locate / ) {    # module doesn't exist
                 DEBUG and warn "Can't load '$controller'";
 
                 # don't do `next` here because controller could be


### PR DESCRIPTION
Module::Load is vulnerable to path traversal attacks; See
https://rt.cpan.org/Public/Bug/Display.html?id=106128

Module::Runtime is a Dancer2 dependency (with the next D2 release replacing
the Class::Load wrapper with explicit use of Module::Runtime), so this
doesn't add any further dependencies to those using the plugin.