### PR TITLE
Pass method args into generated route coderefs

### DIFF
--- a/lib/Dancer2/Plugin/Swagger2.pm
+++ b/lib/Dancer2/Plugin/Swagger2.pm
@@ -152,6 +152,8 @@ register swagger2 => sub {
 
             $dsl->$http_method(
                 $dancer2_path => sub {
+                    my @args = @_;
+
                     if ($validate_requests) {
                         my @errors =
                           _validate_request( $method_spec, $dsl->request );
@@ -163,7 +165,7 @@ register swagger2 => sub {
                         }
                     }
 
-                    my $result = $coderef->();
+                    my $result = $coderef->(@args);
 
                     if ($validate_responses) {
                         my @errors =

--- a/t/basic.t
+++ b/t/basic.t
@@ -6,11 +6,13 @@ use warnings;
 use Test::More;
 use Test::Requires 'YAML::XS';
 
-plan tests => 3;
+plan tests => 5;
 
 package MyApp::Controller::Foo;
 
-sub bar { "Hello_World!" }
+sub bar { "Hello_World!"  }
+
+sub baz { shift->send_file( \"Comment ca va", content_type => 'text/plain' ) }
 
 package MyApp;
 
@@ -31,6 +33,10 @@ my $res = $test->request( GET '/api/welcome' );
 like $res->content => qr/hello.+world/i;
 is $res->code      => 200;
 
+$res = $test->request( GET '/api/bonjour' );
+like $res->content => qr/comment ca va/i;
+is $res->code      => 200;
+
 __DATA__
 @@ swagger2.yaml
 ---
@@ -43,6 +49,12 @@ paths:
   /welcome:
     get:
       operationId: Foo::bar
+      responses:
+        200:
+          description: success
+  /bonjour:
+    get:
+      operationId: Foo::baz
       responses:
         200:
           description: success


### PR DESCRIPTION
When Dancer2 dispatches to a routes' coderef, a Dancer2::Core::App
object is passed into the route. This object should be propogated
to the route coderefs generated by this plugin.